### PR TITLE
Fix corresponding planner item not highlighted when 'total credit' or 'total AU' focused

### DIFF
--- a/src/components/CreditBar.js
+++ b/src/components/CreditBar.js
@@ -33,12 +33,13 @@ class CreditBar extends Component {
         ? 1
         : 2;
 
+    const Tag = isCategoryFocused ? 'span' : React.Fragment;
     const text = (
       <>
-        {takenCredit}
+        <Tag>{takenCredit}</Tag>
         {focusPosition === 1 && <span>{`(${focusedCredit})`}</span>}
         {' \u2192 '}
-        {takenCredit + plannedCredit}
+        <Tag>{takenCredit + plannedCredit}</Tag>
         {focusPosition === 2 && <span>{`(${focusedCredit})`}</span>}
         {focusPosition === 3 && <span>{`+${focusedCredit}`}</span>}
         {' / '}

--- a/src/utils/itemFocusUtils.js
+++ b/src/utils/itemFocusUtils.js
@@ -35,16 +35,16 @@ export const isMultipleFocusedItem = (item, itemFocus, planner) => {
   }
   const focusedCategory = itemFocus.category;
   const itemCategory = getCategoryOfItem(planner, item);
+  if (focusedCategory[0] === CategoryFirstIndex.TOTAL) {
+    if (focusedCategory[2] === 0) {
+      return getCreditOfItem(item) > 0;
+    }
+    return getAuOfItem(item) > 0;
+  }
   if (focusedCategory[0] !== itemCategory[0]) {
     return false;
   }
   switch (focusedCategory[0]) {
-    case CategoryFirstIndex.TOTAL: {
-      if (focusedCategory[2] === 0) {
-        return getCreditOfItem(item) > 0;
-      }
-      return getAuOfItem(item) > 0;
-    }
     case CategoryFirstIndex.MAJOR: {
       const targetSmt = getSeparateMajorTracks(planner)[focusedCategory[1]];
       if (targetSmt.major_required === 0) {


### PR DESCRIPTION
모의시간표와 비슷하게, 졸업플래너에서도 우측 학점 요약에 마우스를 올리면 해당하는 플래너에서 분류에 해당하는 타일이 강조됩니다.
<img width="800" alt="스크린샷 2023-05-30 오후 4 13 50" src="https://github.com/sparcs-kaist/otlplus-web/assets/13213569/5c423114-0416-466c-91c0-9d740ca70418">
하지만 전체의 경우 아래와 같이 강조가 나타나지 않아 수정하였습니다.
원래 구현되어 있었으나 26f39a5 에서 비교 함수 리팩토링 과정에서 누락된 것 같습니다.
<img width="800" alt="스크린샷 2023-05-30 오후 4 14 09" src="https://github.com/sparcs-kaist/otlplus-web/assets/13213569/8a0b6fde-cbf8-4ff5-9242-4b50f5b22e3b">
또한 0학점인 경우 강조 여부를 알기 어려워 글씨에도 하이라이트 색상을 추가하였습니다.