### PR TITLE
chore: disable pr preview on migration branch

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -2,6 +2,7 @@ name: PR Preview
 
 on:
   pull_request:
+    branches: [main]
     types:
       - opened
       - reopened


### PR DESCRIPTION
@yumincho 님의 요청으로 migration 브랜치로 머지하는 PR에서는 pr-preview action을 실행하지 않습니다.

<img width="481" alt="스크린샷 2024-03-13 오후 2 11 20" src="https://github.com/sparcs-kaist/otlplus-web/assets/30364442/028a05fa-4a2b-4968-93f0-b6c72fef73a7">
