### PR TITLE
Migrate Lecture related block components to TypeScript

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,6 +36,10 @@ module.exports = {
   },
   plugins: ['@typescript-eslint', 'react', 'prettier'],
   rules: {
+    '@typescript-eslint/naming-convention': [
+      'error',
+      { selector: 'typeLike', format: ['PascalCase'] },
+    ],
     'no-console': 'error',
     'linebreak-style': 'off',
     'import/extensions': 'off',

--- a/src/components/blocks/LectureGroupBlock.tsx
+++ b/src/components/blocks/LectureGroupBlock.tsx
@@ -5,16 +5,15 @@ import { appBoundClassNames as classNames } from '../../common/boundClassNames';
 import lecture from '../../shapes/model/subject/Lecture';
 import { useTranslatedString } from '@/hooks/useTranslatedString';
 
-interface lectureGroupBlockProps {
+interface LectureGroupBlockProps {
   lectureGroup: lecture[];
   isRaised: boolean;
   isDimmed: boolean;
   isTaken: boolean;
   children?: React.ReactNode;
-  haha: lecture;
 }
 
-const LectureGroupBlock: React.FC<lectureGroupBlockProps> = ({
+const LectureGroupBlock: React.FC<LectureGroupBlockProps> = ({
   lectureGroup,
   isRaised,
   isDimmed,

--- a/src/components/blocks/LectureGroupBlock.tsx
+++ b/src/components/blocks/LectureGroupBlock.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { appBoundClassNames as classNames } from '../../common/boundClassNames';
 
 import lecture from '../../shapes/model/subject/Lecture';
+import { useTranslatedString } from '@/hooks/useTranslatedString';
 
 interface lectureGroupBlockProps {
   lectureGroup: lecture[];
@@ -10,6 +11,7 @@ interface lectureGroupBlockProps {
   isDimmed: boolean;
   isTaken: boolean;
   children?: React.ReactNode;
+  haha: lecture;
 }
 
 const LectureGroupBlock: React.FC<lectureGroupBlockProps> = ({
@@ -20,6 +22,7 @@ const LectureGroupBlock: React.FC<lectureGroupBlockProps> = ({
   children,
 }) => {
   const { t } = useTranslation();
+  const translate = useTranslatedString();
 
   return (
     <div
@@ -32,7 +35,8 @@ const LectureGroupBlock: React.FC<lectureGroupBlockProps> = ({
       )}>
       <div className={classNames('block__completed-text')}>{t('ui.others.taken')}</div>
       <div className={classNames('block--lecture-group__title')}>
-        <strong>{lectureGroup[0][t('js.property.common_title')]}</strong> {lectureGroup[0].old_code}
+        <strong>{translate(lectureGroup[0], 'common_title')}</strong>
+        {lectureGroup[0].old_code}
       </div>
       {children}
     </div>

--- a/src/components/blocks/LectureGroupBlockRow.tsx
+++ b/src/components/blocks/LectureGroupBlockRow.tsx
@@ -1,10 +1,9 @@
-import React from 'react';
-import { useTranslation } from 'react-i18next';
-
 import { appBoundClassNames as classNames } from '../../common/boundClassNames';
 import { getProfessorsShortStr, getClassroomStr } from '../../utils/lectureUtils';
 
 import lecture from '../../shapes/model/subject/Lecture';
+import { useTranslatedString } from '@/hooks/useTranslatedString';
+import React from 'react';
 
 type lectureVoidFunc = (x: lecture) => void;
 interface lectureGroupBlockRowProps {
@@ -36,8 +35,7 @@ const LectureGroupBlockRow: React.FC<lectureGroupBlockRowProps> = ({
   onMouseOut,
   onClick,
 }) => {
-  const { t } = useTranslation();
-  const getClass = (lec) => {
+  const getClass = (lec: lecture) => {
     switch (lec.class_title.length) {
       case 1:
         return classNames('block--lecture-group__row-content__texts__main__fixed-1');
@@ -49,29 +47,29 @@ const LectureGroupBlockRow: React.FC<lectureGroupBlockRowProps> = ({
   };
 
   const handleMouseOver = onMouseOver
-    ? (event) => {
+    ? () => {
         onMouseOver(lecture);
       }
     : undefined;
   const handleMouseOut = onMouseOut
-    ? (event) => {
+    ? () => {
         onMouseOut(lecture);
       }
     : undefined;
   const handleClick = onClick
-    ? (event) => {
+    ? () => {
         onClick(lecture);
       }
     : undefined;
-  const handleDeleteFromCartClick = (event) => {
+  const handleDeleteFromCartClick = (event: MouseEvent) => {
     event.stopPropagation();
     deleteFromCart(lecture);
   };
-  const handleAddToCartClick = (event) => {
+  const handleAddToCartClick = (event: MouseEvent) => {
     event.stopPropagation();
     addToCart(lecture);
   };
-  const handleAddToTableClick = (event) => {
+  const handleAddToTableClick = (event: MouseEvent) => {
     event.stopPropagation();
     addToTable(lecture);
   };
@@ -79,13 +77,13 @@ const LectureGroupBlockRow: React.FC<lectureGroupBlockRowProps> = ({
   const cartButton = fromCart ? (
     <button
       className={classNames('block--lecture-group__row-content__button')}
-      onClick={handleDeleteFromCartClick}>
+      onClick={() => handleDeleteFromCartClick}>
       <i className={classNames('icon', 'icon--delete-cart')} />
     </button>
   ) : !inCart ? (
     <button
       className={classNames('block--lecture-group__row-content__button')}
-      onClick={handleAddToCartClick}>
+      onClick={() => handleAddToCartClick}>
       <i className={classNames('icon', 'icon--add-cart')} />
     </button>
   ) : (
@@ -101,7 +99,7 @@ const LectureGroupBlockRow: React.FC<lectureGroupBlockRowProps> = ({
     !inTimetable && !isTimetableReadonly ? (
       <button
         className={classNames('block--lecture-group__row-content__button')}
-        onClick={handleAddToTableClick}>
+        onClick={() => handleAddToTableClick}>
         <i className={classNames('icon', 'icon--add-lecture')} />
       </button>
     ) : (
@@ -113,6 +111,8 @@ const LectureGroupBlockRow: React.FC<lectureGroupBlockRowProps> = ({
         <i className={classNames('icon', 'icon--add-lecture')} />
       </button>
     );
+
+  const translate = useTranslatedString();
 
   return (
     <div
@@ -127,12 +127,12 @@ const LectureGroupBlockRow: React.FC<lectureGroupBlockRowProps> = ({
       <div className={classNames('block--lecture-group__row-content')}>
         <div className={classNames('block--lecture-group__row-content__texts')}>
           <div className={classNames('block--lecture-group__row-content__texts__sub')}>
-            {lecture[t('js.property.department_name')]}
+            {translate(lecture, 'department_name')}
             {' / '}
-            {lecture[t('js.property.type')]}
+            {translate(lecture, 'type')}
           </div>
           <div className={classNames('block--lecture-group__row-content__texts__main')}>
-            <strong className={getClass(lecture)}>{lecture[t('js.property.class_title')]}</strong>{' '}
+            <strong className={getClass(lecture)}>{translate(lecture, 'class_title')}</strong>{' '}
             <span>{getProfessorsShortStr(lecture)}</span>
           </div>
           <div className={classNames('block--lecture-group__row-content__texts__sub')}>

--- a/src/components/blocks/LectureGroupBlockRow.tsx
+++ b/src/components/blocks/LectureGroupBlockRow.tsx
@@ -2,26 +2,27 @@ import React from 'react';
 
 import { appBoundClassNames as classNames } from '../../common/boundClassNames';
 import { getProfessorsShortStr, getClassroomStr } from '../../utils/lectureUtils';
-import lecture from '../../shapes/model/subject/Lecture';
+import Lecture from '@/shapes/model/subject/Lecture';
 import { useTranslatedString } from '@/hooks/useTranslatedString';
 
-type lectureVoidFunc = (x: lecture) => void;
-interface lectureGroupBlockRowProps {
-  lecture: lecture;
+type LectureVoidFunc = (x: Lecture) => void;
+
+interface LectureGroupBlockRowProps {
+  lecture: Lecture;
   isHighlighted: boolean;
   inTimetable: boolean;
   isTimetableReadonly: boolean;
   inCart: boolean;
   fromCart: boolean;
-  addToCart: lectureVoidFunc;
-  addToTable: lectureVoidFunc;
-  deleteFromCart: lectureVoidFunc;
-  onMouseOver?: lectureVoidFunc;
-  onMouseOut?: lectureVoidFunc;
-  onClick?: lectureVoidFunc;
+  addToCart: LectureVoidFunc;
+  addToTable: LectureVoidFunc;
+  deleteFromCart: LectureVoidFunc;
+  onMouseOver?: LectureVoidFunc;
+  onMouseOut?: LectureVoidFunc;
+  onClick?: LectureVoidFunc;
 }
 
-const LectureGroupBlockRow: React.FC<lectureGroupBlockRowProps> = ({
+const LectureGroupBlockRow: React.FC<LectureGroupBlockRowProps> = ({
   lecture,
   isHighlighted,
   inTimetable,
@@ -35,8 +36,8 @@ const LectureGroupBlockRow: React.FC<lectureGroupBlockRowProps> = ({
   onMouseOut,
   onClick,
 }) => {
-  const getClass = (lec: lecture) => {
-    switch (lec.class_title.length) {
+  const getClass = (lecture: Lecture) => {
+    switch (lecture.class_title.length) {
       case 1:
         return classNames('block--lecture-group__row-content__texts__main__fixed-1');
       case 2:

--- a/src/components/blocks/LectureGroupBlockRow.tsx
+++ b/src/components/blocks/LectureGroupBlockRow.tsx
@@ -1,9 +1,9 @@
+import React from 'react';
+
 import { appBoundClassNames as classNames } from '../../common/boundClassNames';
 import { getProfessorsShortStr, getClassroomStr } from '../../utils/lectureUtils';
-
 import lecture from '../../shapes/model/subject/Lecture';
 import { useTranslatedString } from '@/hooks/useTranslatedString';
-import React from 'react';
 
 type lectureVoidFunc = (x: lecture) => void;
 interface lectureGroupBlockRowProps {
@@ -61,15 +61,15 @@ const LectureGroupBlockRow: React.FC<lectureGroupBlockRowProps> = ({
         onClick(lecture);
       }
     : undefined;
-  const handleDeleteFromCartClick = (event: MouseEvent) => {
+  const handleDeleteFromCartClick = (event: React.MouseEvent) => {
     event.stopPropagation();
     deleteFromCart(lecture);
   };
-  const handleAddToCartClick = (event: MouseEvent) => {
+  const handleAddToCartClick = (event: React.MouseEvent) => {
     event.stopPropagation();
     addToCart(lecture);
   };
-  const handleAddToTableClick = (event: MouseEvent) => {
+  const handleAddToTableClick = (event: React.MouseEvent) => {
     event.stopPropagation();
     addToTable(lecture);
   };
@@ -77,13 +77,13 @@ const LectureGroupBlockRow: React.FC<lectureGroupBlockRowProps> = ({
   const cartButton = fromCart ? (
     <button
       className={classNames('block--lecture-group__row-content__button')}
-      onClick={() => handleDeleteFromCartClick}>
+      onClick={handleDeleteFromCartClick}>
       <i className={classNames('icon', 'icon--delete-cart')} />
     </button>
   ) : !inCart ? (
     <button
       className={classNames('block--lecture-group__row-content__button')}
-      onClick={() => handleAddToCartClick}>
+      onClick={handleAddToCartClick}>
       <i className={classNames('icon', 'icon--add-cart')} />
     </button>
   ) : (
@@ -99,7 +99,7 @@ const LectureGroupBlockRow: React.FC<lectureGroupBlockRowProps> = ({
     !inTimetable && !isTimetableReadonly ? (
       <button
         className={classNames('block--lecture-group__row-content__button')}
-        onClick={() => handleAddToTableClick}>
+        onClick={handleAddToTableClick}>
         <i className={classNames('icon', 'icon--add-lecture')} />
       </button>
     ) : (

--- a/src/components/blocks/LectureGroupBlockRow.tsx
+++ b/src/components/blocks/LectureGroupBlockRow.tsx
@@ -46,21 +46,6 @@ const LectureGroupBlockRow: React.FC<lectureGroupBlockRowProps> = ({
     }
   };
 
-  const handleMouseOver = onMouseOver
-    ? () => {
-        onMouseOver(lecture);
-      }
-    : undefined;
-  const handleMouseOut = onMouseOut
-    ? () => {
-        onMouseOut(lecture);
-      }
-    : undefined;
-  const handleClick = onClick
-    ? () => {
-        onClick(lecture);
-      }
-    : undefined;
   const handleDeleteFromCartClick = (event: React.MouseEvent) => {
     event.stopPropagation();
     deleteFromCart(lecture);
@@ -121,9 +106,9 @@ const LectureGroupBlockRow: React.FC<lectureGroupBlockRowProps> = ({
         isHighlighted ? 'block--lecture-group__row--highlighted' : null,
       )}
       data-id={lecture.id}
-      onClick={handleClick}
-      onMouseOver={handleMouseOver}
-      onMouseOut={handleMouseOut}>
+      onClick={() => onClick?.(lecture)}
+      onMouseOver={() => onMouseOver?.(lecture)}
+      onMouseOut={() => onMouseOut?.(lecture)}>
       <div className={classNames('block--lecture-group__row-content')}>
         <div className={classNames('block--lecture-group__row-content__texts')}>
           <div className={classNames('block--lecture-group__row-content__texts__sub')}>

--- a/src/components/blocks/LectureGroupSimpleBlock.tsx
+++ b/src/components/blocks/LectureGroupSimpleBlock.tsx
@@ -1,17 +1,16 @@
 import React from 'react';
-import { useTranslation } from 'react-i18next';
 
 import { appBoundClassNames as classNames } from '../../common/boundClassNames';
 import { getProfessorsShortStr } from '../../utils/lectureUtils';
 import lecture from '../../shapes/model/subject/Lecture';
+import { useTranslatedString } from '@/hooks/useTranslatedString';
 
 interface lectureGroupSimpleBlockProps {
   lectures: lecture[];
 }
 
 const LectureGroupSimpleBlock: React.FC<lectureGroupSimpleBlockProps> = ({ lectures }) => {
-  const { t } = useTranslation();
-  const getClass = (lecture) => {
+  const getClass = (lecture: lecture) => {
     if (!lecture.class_title) {
       return classNames('');
     }
@@ -24,13 +23,16 @@ const LectureGroupSimpleBlock: React.FC<lectureGroupSimpleBlockProps> = ({ lectu
         return classNames('');
     }
   };
+
+  const translate = useTranslatedString();
+
   return (
     <div className={classNames('block', 'block--lecture-group-simple')}>
       {lectures.map((l) => (
         <div className={classNames('block--lecture-group-simple__row')} key={l.id}>
           <div className={classNames('block--lecture-group-simple__row-content')}>
             <div className={classNames('block--lecture-group-simple__row-content__texts')}>
-              <strong className={getClass(l)}>{l[t('js.property.class_title')]}</strong>{' '}
+              <strong className={getClass(l)}>{translate(l, 'class_title')}</strong>{' '}
               <span>{getProfessorsShortStr(l)}</span>
             </div>
           </div>

--- a/src/components/blocks/LectureGroupSimpleBlock.tsx
+++ b/src/components/blocks/LectureGroupSimpleBlock.tsx
@@ -2,15 +2,15 @@ import React from 'react';
 
 import { appBoundClassNames as classNames } from '../../common/boundClassNames';
 import { getProfessorsShortStr } from '../../utils/lectureUtils';
-import lecture from '../../shapes/model/subject/Lecture';
+import Lecture from '@/shapes/model/subject/Lecture';
 import { useTranslatedString } from '@/hooks/useTranslatedString';
 
-interface lectureGroupSimpleBlockProps {
-  lectures: lecture[];
+interface LectureGroupSimpleBlockProps {
+  lectures: Lecture[];
 }
 
-const LectureGroupSimpleBlock: React.FC<lectureGroupSimpleBlockProps> = ({ lectures }) => {
-  const getClass = (lecture: lecture) => {
+const LectureGroupSimpleBlock: React.FC<LectureGroupSimpleBlockProps> = ({ lectures }) => {
+  const getClass = (lecture: Lecture) => {
     if (!lecture.class_title) {
       return classNames('');
     }

--- a/src/components/blocks/LectureSimpleBlock.tsx
+++ b/src/components/blocks/LectureSimpleBlock.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { appBoundClassNames as classNames } from '../../common/boundClassNames';
 
 import lecture from '@/shapes/model/subject/Lecture';
+import { useTranslatedString } from '@/hooks/useTranslatedString';
 interface lectureSimpleBlockProps {
   lecture: lecture;
   isRaised: boolean;
@@ -21,10 +22,12 @@ const LectureSimpleBlock: React.FC<lectureSimpleBlockProps> = ({
   const { t } = useTranslation();
 
   const handleClick = onClick
-    ? (event) => {
+    ? () => {
         onClick(lecture);
       }
     : undefined;
+
+  const translate = useTranslatedString();
 
   return (
     <div
@@ -39,7 +42,7 @@ const LectureSimpleBlock: React.FC<lectureSimpleBlockProps> = ({
       onClick={handleClick}>
       <div className={classNames('block__completed-text')}>{t('ui.others.written')}</div>
       <div className={classNames('block--lecture-simple__title')}>
-        {lecture[t('js.property.title')]}
+        {translate(lecture, 'title')}
       </div>
       <div className={classNames('block--lecture-simple__subtitle')}>{lecture.old_code}</div>
     </div>

--- a/src/components/blocks/LectureSimpleBlock.tsx
+++ b/src/components/blocks/LectureSimpleBlock.tsx
@@ -21,12 +21,6 @@ const LectureSimpleBlock: React.FC<LectureSimpleBlockProps> = ({
 }) => {
   const { t } = useTranslation();
 
-  const handleClick = onClick
-    ? () => {
-        onClick(lecture);
-      }
-    : undefined;
-
   const translate = useTranslatedString();
 
   return (
@@ -39,7 +33,7 @@ const LectureSimpleBlock: React.FC<LectureSimpleBlockProps> = ({
         isDimmed ? 'block--dimmed' : null,
         hasReview ? 'block--completed' : null,
       )}
-      onClick={handleClick}>
+      onClick={() => onClick?.(lecture)}>
       <div className={classNames('block__completed-text')}>{t('ui.others.written')}</div>
       <div className={classNames('block--lecture-simple__title')}>
         {translate(lecture, 'title')}

--- a/src/components/blocks/LectureSimpleBlock.tsx
+++ b/src/components/blocks/LectureSimpleBlock.tsx
@@ -3,14 +3,15 @@ import { useTranslation } from 'react-i18next';
 
 import { appBoundClassNames as classNames } from '../../common/boundClassNames';
 
-import lecture from '@/shapes/model/subject/Lecture';
+import Lecture from '@/shapes/model/subject/Lecture';
 import { useTranslatedString } from '@/hooks/useTranslatedString';
+
 interface LectureSimpleBlockProps {
-  lecture: lecture;
+  lecture: Lecture;
   isRaised: boolean;
   isDimmed: boolean;
   hasReview: boolean;
-  onClick?: (x: lecture) => void;
+  onClick?: (x: Lecture) => void;
 }
 const LectureSimpleBlock: React.FC<LectureSimpleBlockProps> = ({
   lecture,

--- a/src/components/blocks/LectureSimpleBlock.tsx
+++ b/src/components/blocks/LectureSimpleBlock.tsx
@@ -5,14 +5,14 @@ import { appBoundClassNames as classNames } from '../../common/boundClassNames';
 
 import lecture from '@/shapes/model/subject/Lecture';
 import { useTranslatedString } from '@/hooks/useTranslatedString';
-interface lectureSimpleBlockProps {
+interface LectureSimpleBlockProps {
   lecture: lecture;
   isRaised: boolean;
   isDimmed: boolean;
   hasReview: boolean;
   onClick?: (x: lecture) => void;
 }
-const LectureSimpleBlock: React.FC<lectureSimpleBlockProps> = ({
+const LectureSimpleBlock: React.FC<LectureSimpleBlockProps> = ({
   lecture,
   isRaised,
   isDimmed,

--- a/src/components/blocks/__tests__/render.test.tsx
+++ b/src/components/blocks/__tests__/render.test.tsx
@@ -1,0 +1,47 @@
+import { render, sampleLecture } from '@/test-utils';
+import LectureGroupBlock from '../LectureGroupBlock';
+import LectureGroupBlockRow from '../LectureGroupBlockRow';
+import LectureGroupSimpleBlock from '../LectureGroupSimpleBlock';
+import LectureSimpleBlock from '../LectureSimpleBlock';
+
+test('render LectureGroupBlock', async () => {
+  render(
+    <LectureGroupBlock
+      lectureGroup={[sampleLecture]}
+      isRaised={false}
+      isDimmed={false}
+      isTaken={false}
+    />,
+  );
+});
+
+test('render LectureGroupBlockRow', async () => {
+  render(
+    <LectureGroupBlockRow
+      lecture={sampleLecture}
+      isHighlighted={false}
+      inTimetable={false}
+      isTimetableReadonly={false}
+      inCart={false}
+      fromCart={false}
+      addToCart={() => {}}
+      addToTable={() => {}}
+      deleteFromCart={() => {}}
+    />,
+  );
+});
+
+test('render LectureGroupSimpleBlock', async () => {
+  render(<LectureGroupSimpleBlock lectures={[sampleLecture]} />);
+});
+
+test('render LectureSimpleBlock', async () => {
+  render(
+    <LectureSimpleBlock
+      lecture={sampleLecture}
+      isRaised={false}
+      isDimmed={false}
+      hasReview={false}
+    />,
+  );
+});


### PR DESCRIPTION
### Description
작업 내용:
- @/components/blocks 내 .tsx 파일 4개에 대한 migration 진행
- 기존의 i18n.t 사용하던 부분을 useTranslatedString 사용하도록 변경

### Checklist
- [x] LectureGroupBlock.tsx
- [x] LectureGroupBlockRow.tsx
- [x] LectureGroupSimpleBlock.tsx
- [x] LectureSimpleBlock.tsx

### Identification
LectureGroupBlock.tsx
<img width="1440" alt="LectureGroupBlock" src="https://github.com/sparcs-kaist/otlplus-web/assets/43981717/6935ccd2-96ec-49f0-9e07-d4cbe9b236c6">

LectureGroupBlockRow.tsx
<img width="1440" alt="LectureGroupBlockRow" src="https://github.com/sparcs-kaist/otlplus-web/assets/43981717/58a93dcc-7bb8-4448-83a4-b196edbbd6a3">

LectureGroupSimpleBlock.tsx
<img width="1440" alt="LectureGroupSimpleBlock" src="https://github.com/sparcs-kaist/otlplus-web/assets/43981717/4d363b46-89cd-4700-8260-7c6f96e2f28c">

LectureSimpleBlock.tsx
<img width="1440" alt="LectureSimpleBlock" src="https://github.com/sparcs-kaist/otlplus-web/assets/43981717/530e81b1-f822-46d6-9020-c0db83464349">
