### PR TITLE
Fix PR #59, fix Detail interface in Timetable

### DIFF
--- a/src/actions/timetable/lectureFocus.ts
+++ b/src/actions/timetable/lectureFocus.ts
@@ -1,6 +1,7 @@
 import { LectureFocusFrom } from '@/shapes/enum';
 import Review from '@/shapes/model/review/Review';
 import Lecture from '@/shapes/model/subject/Lecture';
+import { Detail } from '@/shapes/state/timetable/LectureFocus';
 
 const BASE_STRING = 'T_LA_';
 
@@ -10,12 +11,6 @@ export const CLEAR_LECTURE_FOCUS = `${BASE_STRING}CLEAR_LECTURE_FOCUS` as const;
 export const SET_REVIEWS = `${BASE_STRING}SET_REVIEWS` as const;
 export const SET_MULTIPLE_FOCUS = `${BASE_STRING}SET_MULTIPLE_FOCUS` as const;
 export const CLEAR_MULTIPLE_FOCUS = `${BASE_STRING}CLEAR_MULTIPLE_FOCUS` as const;
-
-interface LectureDetail {
-  lecture: Lecture;
-  name: string;
-  info: string;
-}
 
 export function reset() {
   return {
@@ -45,7 +40,7 @@ export function setReviews(reviews: Review[]) {
   };
 }
 
-export function setMultipleFocus(multipleTitle: string, multipleDetails: LectureDetail[]) {
+export function setMultipleFocus(multipleTitle: string, multipleDetails: Detail[]) {
   return {
     type: SET_MULTIPLE_FOCUS,
     multipleTitle: multipleTitle,

--- a/src/shapes/state/timetable/LectureFocus.ts
+++ b/src/shapes/state/timetable/LectureFocus.ts
@@ -4,7 +4,7 @@ import type Review from '@/shapes/model/review/Review';
 
 type EmtpyArray = [];
 export interface Detail {
-  lecture?: Lecture;
+  lecture: Lecture;
   name: string;
   info: string;
 }


### PR DESCRIPTION
SET_MULTIPLE_FOCUS 액션에서 사용되는 Detail interface 를 변경하였습니다. 

SET_MULTIPLE_FOCUS 는 아래 5가지 경우에 dispatch 가 되고, 각 경우에 대해서 테스팅완료하였습니다!
1. MapSubsection 의 특정 건물 위에  hover 
2. SummarySubsection 의  (a)과목 구분 (b)학점 (c)성적 위에 각각 호버하였을 때
3. ExamSubsection 의 특정 건물 위에 hover



```
export function setMultipleFocus(multipleTitle: string, multipleDetails: Detail[]) {
  return {
    type: SET_MULTIPLE_FOCUS,
    multipleTitle: multipleTitle,
    multipleDetails: multipleDetails,
  };
}
```
아래처럼  lecture list(Lecture[])를 구한뒤, 이를 매핑하여 Detail 로 사용하기 때문에 name 이 있는데, lecture 이 undefined인 경우는 없어, detail interface 에서 lecture의 optional 을 제거하였습니다.
<img width="638" alt="image" src="https://github.com/sparcs-kaist/otlplus-web/assets/86822199/eefcfef2-e806-426e-8901-2aa6774050f0">
