### PR TITLE
Use backend current semester API

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,6 +2,7 @@ module.exports = {
   presets: ['@babel/preset-env', '@babel/preset-react'],
   plugins: [
     '@babel/plugin-syntax-jsx',
+    '@babel/plugin-syntax-import-meta',
     ['@babel/plugin-proposal-decorators', { version: '2023-11' }],
   ],
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,13 @@ import Header from '@/common/guideline/components/Header';
 import BannerPopup from '@/common/components/popup/bannerPopup/BannerPopup';
 import CampaignPopupImage from '@/features/campaign/components/popup/CampaignPopupImage';
 import PopupMenu from '@/features/campaign/components/popup/PopupMenu';
-import { setIsPortrait, setSemesters, setTracks, setUser } from '@/redux/actions/common';
+import {
+  setIsPortrait,
+  setSemesters,
+  setTracks,
+  setUser,
+  setCurrentSemester,
+} from '@/redux/actions/common';
 
 const App: React.FC = () => {
   const dispatch = useDispatch();
@@ -65,6 +71,13 @@ const App: React.FC = () => {
       })
       .then((response) => {
         dispatch(setSemesters(response.data));
+      })
+      .catch(() => {});
+
+    axios
+      .get('/api/semesters/current')
+      .then((response) => {
+        dispatch(setCurrentSemester(response.data));
       })
       .catch(() => {});
 

--- a/src/common/guideline/components/Header.jsx
+++ b/src/common/guideline/components/Header.jsx
@@ -158,7 +158,7 @@ class Header extends Component {
                     <i className={classNames('icon--header_user')} />
                     <span>{t('ui.placeholder.loading')}</span>
                   </span>
-                ) : import.meta.env.VITE_DEV_MODE === 'true' ? (
+                ) : process.env.VITE_DEV_MODE === 'true' ? (
                   <Link to="/developer-login">
                     <i className={classNames('icon--header_user')} />
                     <span>{t('ui.menu.signIn')} (Dev)</span>

--- a/src/components/sections/main/TodaysTimetableSection.jsx
+++ b/src/components/sections/main/TodaysTimetableSection.jsx
@@ -87,9 +87,10 @@ class TodaysTimetableSection extends Component {
   render() {
     const { t } = this.props;
     const { cellWidth, cellHeight, now } = this.state;
-    const { user, semesters } = this.props;
+    const { user, semesters, currentSemester } = this.props;
 
-    const ongoingSemester = semesters ? getOngoingSemester(semesters) : undefined;
+    const ongoingSemester =
+      currentSemester || (semesters ? getOngoingSemester(semesters) : undefined);
     const lectures =
       user && ongoingSemester
         ? user.my_timetable_lectures.filter(
@@ -227,6 +228,7 @@ class TodaysTimetableSection extends Component {
 const mapStateToProps = (state) => ({
   user: state.common.user.user,
   semesters: state.common.semester.semesters,
+  currentSemester: state.common.semester.currentSemester,
 });
 
 const mapDispatchToProps = (dispatch) => ({});
@@ -234,6 +236,7 @@ const mapDispatchToProps = (dispatch) => ({});
 TodaysTimetableSection.propTypes = {
   user: userShape,
   semesters: PropTypes.arrayOf(semesterShape),
+  currentSemester: semesterShape,
 };
 
 export default withTranslation()(

--- a/src/components/sections/write-reviews/reviewsright/RankedReviewsSubSection.jsx
+++ b/src/components/sections/write-reviews/reviewsright/RankedReviewsSubSection.jsx
@@ -74,12 +74,21 @@ class RankedReviewsSubSection extends Component {
   }
 
   _getTargetSemesters = () => {
-    const { semesters } = this.props;
+    const { semesters, currentSemester } = this.props;
 
     const now = new Date();
-    return semesters.filter(
+    const filtered = semesters.filter(
       (s) => s.year >= 2013 && now - new Date(s.gradePosting) > 30 * 24 * 60 * 60 * 1000,
     );
+    if (
+      currentSemester &&
+      !filtered.find(
+        (s) => s.year === currentSemester.year && s.semester === currentSemester.semester,
+      )
+    ) {
+      filtered.push(currentSemester);
+    }
+    return filtered.sort((a, b) => a.year - b.year || a.semester - b.semester);
   };
 
   _getSemesterKey = (semester) => {
@@ -307,6 +316,7 @@ class RankedReviewsSubSection extends Component {
 
 const mapStateToProps = (state) => ({
   semesters: state.common.semester.semesters,
+  currentSemester: state.common.semester.currentSemester,
   reviewsFocus: state.writeReviews.reviewsFocus,
   reviewsBySemester: state.writeReviews.rankedReviews.reviewsBySemester,
   reviewCountBySemester: state.writeReviews.rankedReviews.reviewCountBySemester,
@@ -326,6 +336,7 @@ const mapDispatchToProps = (dispatch) => ({
 
 RankedReviewsSubSection.propTypes = {
   semesters: PropTypes.arrayOf(semesterShape),
+  currentSemester: semesterShape,
   reviewsFocus: reviewsFocusShape.isRequired,
   reviewsBySemester: PropTypes.objectOf(PropTypes.arrayOf(reviewShape)).isRequired,
   reviewCountBySemester: PropTypes.objectOf(PropTypes.number).isRequired,

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -286,7 +286,7 @@ class MainPage extends Component {
                 <span onClick={() => this._fetchFeeds(this._getPrevDate())}>
                   {t('ui.button.loadMore')}
                 </span>
-              ) : import.meta.env.VITE_DEV_MODE === 'true' ? (
+              ) : process.env.VITE_DEV_MODE === 'true' ? (
                 <Link to="/developer-login">{t('ui.button.signInWithSso')}</Link>
               ) : (
                 <>

--- a/src/redux/actions/common/semester.ts
+++ b/src/redux/actions/common/semester.ts
@@ -1,6 +1,7 @@
 const BASE_STRING = 'C_S_';
 
 export const SET_SEMESTERS = `${BASE_STRING}SET_SEMESTERS` as const;
+export const SET_CURRENT_SEMESTER = `${BASE_STRING}SET_CURRENT_SEMESTER` as const;
 
 import Semester from '@/shapes/model/subject/Semester';
 
@@ -11,4 +12,13 @@ export function setSemesters(semesters: Semester[]) {
   };
 }
 
-export type SemesterAction = ReturnType<typeof setSemesters>;
+export function setCurrentSemester(semester: Semester) {
+  return {
+    type: SET_CURRENT_SEMESTER,
+    semester,
+  };
+}
+
+export type SemesterAction =
+  | ReturnType<typeof setSemesters>
+  | ReturnType<typeof setCurrentSemester>;

--- a/src/redux/reducers/common/semester.ts
+++ b/src/redux/reducers/common/semester.ts
@@ -1,18 +1,22 @@
-import { SET_SEMESTERS, SemesterAction } from '../../actions/common/semester';
+import { SET_SEMESTERS, SET_CURRENT_SEMESTER, SemesterAction } from '../../actions/common/semester';
 import Semester from '@/shapes/model/subject/Semester';
 
 interface SemesterState {
   semesters: Semester[] | null;
+  currentSemester: Semester | null;
 }
 
 const initialState: SemesterState = {
   semesters: null,
+  currentSemester: null,
 };
 
 const semester = (state = initialState, action: SemesterAction): SemesterState => {
   switch (action.type) {
     case SET_SEMESTERS:
       return { ...state, semesters: action.semesters };
+    case SET_CURRENT_SEMESTER:
+      return { ...state, currentSemester: action.semester };
     default:
       return state;
   }


### PR DESCRIPTION
## Summary
- add babel plugin for `import.meta`
- fetch current semester from new endpoint
- store current semester in redux
- show current semester in timetable and Hall of Fame sections
- support tests by reading `VITE_DEV_MODE` from process.env

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_b_685aca12179c832ea6e79cc45f05f994