### PR TITLE
Enable paged search for Dictionary

### DIFF
--- a/src/components/sections/dictionary/courselist/CourseListSection.jsx
+++ b/src/components/sections/dictionary/courselist/CourseListSection.jsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { withTranslation } from 'react-i18next';
 import ReactGA from 'react-ga4';
+import axios from 'axios';
 
 import { appBoundClassNames as classNames } from '../../../../common/boundClassNames';
 
@@ -15,6 +16,7 @@ import CourseBlock from '../../../blocks/CourseBlock';
 import { isFocused, isDimmedCourse } from '../../../../utils/courseUtils';
 import { setCourseFocus, clearCourseFocus } from '../../../../actions/dictionary/courseFocus';
 import { openSearch } from '../../../../actions/dictionary/search';
+import { setListCourses } from '../../../../actions/dictionary/list';
 
 import courseShape from '../../../../shapes/model/subject/CourseShape';
 import courseFocusShape from '../../../../shapes/state/dictionary/CourseFocusShape';
@@ -31,6 +33,16 @@ import {
 } from '../../../../common/searchOptions';
 
 class CourseListSection extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      isLoading: false,
+      reachedEnd: false,
+    };
+
+    this.blockListRef = React.createRef();
+  }
   showSearch = () => {
     const { openSearchDispatch } = this.props;
     openSearchDispatch();
@@ -82,6 +94,68 @@ class CourseListSection extends Component {
       return null;
     }
     return lists[selectedListCode].courses;
+  };
+
+  _fetchMoreCourses = () => {
+    const { selectedListCode, lastSearchOption, lists, setListCoursesDispatch } = this.props;
+
+    if (selectedListCode !== CourseListCode.SEARCH) {
+      return;
+    }
+
+    const { isLoading, reachedEnd } = this.state;
+    const PAGE_SIZE = 20;
+
+    if (isLoading || reachedEnd) {
+      return;
+    }
+
+    const currentCourses = lists[CourseListCode.SEARCH].courses || [];
+
+    this.setState({ isLoading: true });
+    axios
+      .get('/api/courses', {
+        params: {
+          ...lastSearchOption,
+          order: ['old_code'],
+          offset: currentCourses.length,
+          limit: PAGE_SIZE,
+        },
+        metadata: {
+          gaCategory: 'Course',
+          gaVariable: 'GET / List',
+        },
+      })
+      .then((response) => {
+        const newCourses = response.data;
+        setListCoursesDispatch(CourseListCode.SEARCH, currentCourses.concat(newCourses));
+        this.setState({
+          isLoading: false,
+          reachedEnd: newCourses.length < PAGE_SIZE,
+        });
+      })
+      .catch(() => {
+        this.setState({ isLoading: false });
+      });
+  };
+
+  handleScroll = () => {
+    const SCROLL_THRESHOLD = 100;
+
+    if (!this.blockListRef.current) {
+      return;
+    }
+
+    const blockListElement = this.blockListRef.current;
+    const scrollElement = blockListElement.closest('.ScrollbarsCustom-Scroller');
+
+    const bottomOffset =
+      blockListElement.getBoundingClientRect().bottom -
+      scrollElement.getBoundingClientRect().bottom;
+
+    if (bottomOffset < SCROLL_THRESHOLD) {
+      this._fetchMoreCourses();
+    }
   };
 
   render() {
@@ -158,8 +232,12 @@ class CourseListSection extends Component {
         );
       }
       return (
-        <Scroller key={selectedListCode}>
-          <div className={classNames('block-list')}>
+        <Scroller
+          key={selectedListCode}
+          onScroll={selectedListCode === CourseListCode.SEARCH ? this.handleScroll : undefined}>
+          <div
+            className={classNames('block-list')}
+            ref={selectedListCode === CourseListCode.SEARCH ? this.blockListRef : null}>
             {courses.map((c) => (
               <CourseBlock
                 course={c}
@@ -207,6 +285,9 @@ const mapDispatchToProps = (dispatch) => ({
   clearCourseFocusDispatch: () => {
     dispatch(clearCourseFocus());
   },
+  setListCoursesDispatch: (code, courses) => {
+    dispatch(setListCourses(code, courses));
+  },
 });
 
 CourseListSection.propTypes = {
@@ -220,6 +301,7 @@ CourseListSection.propTypes = {
   openSearchDispatch: PropTypes.func.isRequired,
   setCourseFocusDispatch: PropTypes.func.isRequired,
   clearCourseFocusDispatch: PropTypes.func.isRequired,
+  setListCoursesDispatch: PropTypes.func.isRequired,
 };
 
 export default withTranslation()(connect(mapStateToProps, mapDispatchToProps)(CourseListSection));

--- a/src/components/sections/dictionary/courselist/CourseSearchSubSection.jsx
+++ b/src/components/sections/dictionary/courselist/CourseSearchSubSection.jsx
@@ -48,7 +48,7 @@ class CourseSearchSubSection extends Component {
   };
 
   searchStart = () => {
-    const LIMIT = 150;
+    const LIMIT = 20;
 
     const { t } = this.props;
     const { selectedTypes, selectedDepartments, selectedLevels, selectedTerms, keyword } =

--- a/src/pages/DictionaryPage.jsx
+++ b/src/pages/DictionaryPage.jsx
@@ -19,7 +19,11 @@ import {
   setListCourses,
   clearSearchListCourses,
 } from '../actions/dictionary/list';
-import { reset as resetSearch, closeSearch } from '../actions/dictionary/search';
+import {
+  reset as resetSearch,
+  closeSearch,
+  setLastSearchOption,
+} from '../actions/dictionary/search';
 import { performSearchCourses } from '../common/commonOperations';
 import { parseQueryString } from '@/common/utils/parseQueryString';
 
@@ -56,7 +60,7 @@ class DictionaryPage extends Component {
     }
 
     if (startSearchKeyword && startSearchKeyword.trim()) {
-      const LIMIT = 150;
+      const LIMIT = 20;
 
       const option = {
         keyword: startSearchKeyword.trim(),
@@ -64,6 +68,7 @@ class DictionaryPage extends Component {
       const beforeRequest = () => {
         closeSearchDispatch();
         clearSearchListCoursesDispatch();
+        setLastSearchOptionDispatch(option);
       };
       const afterResponse = (courses) => {
         if (courses.length === LIMIT) {
@@ -125,6 +130,9 @@ const mapDispatchToProps = (dispatch) => ({
   setListCoursesDispatch: (code, courses) => {
     dispatch(setListCourses(code, courses));
   },
+  setLastSearchOptionDispatch: (option) => {
+    dispatch(setLastSearchOption(option));
+  },
   closeSearchDispatch: () => {
     dispatch(closeSearch());
   },
@@ -148,6 +156,7 @@ DictionaryPage.propTypes = {
   setCourseFocusDispatch: PropTypes.func.isRequired,
   setSelectedListCodeDispatch: PropTypes.func.isRequired,
   setListCoursesDispatch: PropTypes.func.isRequired,
+  setLastSearchOptionDispatch: PropTypes.func.isRequired,
   closeSearchDispatch: PropTypes.func.isRequired,
   clearSearchListCoursesDispatch: PropTypes.func.isRequired,
 };

--- a/src/pages/DictionaryPage.jsx
+++ b/src/pages/DictionaryPage.jsx
@@ -39,6 +39,7 @@ class DictionaryPage extends Component {
       setListCoursesDispatch,
       closeSearchDispatch,
       clearSearchListCoursesDispatch,
+      setLastSearchOptionDispatch,
     } = this.props;
 
     if (startCourseId) {


### PR DESCRIPTION
## Summary
- enable paged search with PAGE_SIZE=20 in `CourseSearchSubSection`
- keep last search option from query string and use small pages in `DictionaryPage`
- add infinite scroll loader in `CourseListSection`

## Testing
- `npm run lint` *(fails: couldn't find eslint config)*
- `npm run prettier` *(fails: code style issues in unrelated files)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687145e09d74832ebc01b5e23d5fd518